### PR TITLE
feat: Implement a lightweight JSX frontend framework with Bun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# dependencies (bun install)
+node_modules
+
+# output
+out
+dist
+*.tgz
+
+# code coverage
+coverage
+*.lcov
+
+# logs
+logs
+_.log
+report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# caches
+.eslintcache
+.cache
+*.tsbuildinfo
+
+# IntelliJ based IDEs
+.idea
+
+# Finder (MacOS) folder config
+.DS_Store

--- a/BUNVOYAGE_README.md
+++ b/BUNVOYAGE_README.md
@@ -1,0 +1,236 @@
+# BunVoyage: A Lightweight UI Framework for Bun
+
+BunVoyage is a minimal, educational UI framework built from scratch to explore the fundamentals of modern frontend development using [Bun](https://bun.sh/) and TypeScript. It's designed to be simple, transparent, and a learning tool for understanding how core features like JSX, components, state management (hooks), and virtual DOM diffing can be implemented.
+
+## ✨ Features
+
+*   **JSX Support**: Write UI using familiar JSX syntax.
+    *   Custom JSX runtime configured via `jsxImportSource`.
+*   **Functional Components**: Build your UI with simple, reusable functions.
+*   **`useState` Hook**: Basic state management for your components.
+*   **Virtual DOM & Diffing**: Efficiently updates the DOM by comparing a virtual representation of the UI.
+    *   Basic reconciliation for elements, text nodes, and components.
+    *   Attribute/prop updates, additions, and removals.
+    *   Simple children reconciliation (add, remove, update in place).
+*   **TypeScript First**: Strongly typed for a better development experience.
+*   **Lightweight & Educational**: Designed for learning and understanding core concepts, not for production scale (yet!).
+*   **Bun Powered**: Leverages Bun for fast development, testing, and running.
+
+## 🚀 Getting Started
+
+This framework is designed to be used within a Bun environment.
+
+### Prerequisites
+
+*   [Bun](https://bun.sh/docs/installation) installed on your system.
+
+### Installation / Setup
+
+1.  **Clone the repository (or set up your project):**
+    If you're working from this template or have the source code:
+    ```bash
+    # No explicit 'npm install' or 'bun install' needed for the framework itself
+    # if you are using it directly from source within the same project.
+    # Bun will transpile TypeScript and JSX on the fly.
+    ```
+    If this were published as a package, you'd install it via `bun add bunvoyage`.
+
+2.  **Configure `tsconfig.json`:**
+    Ensure your `tsconfig.json` is set up for custom JSX with `jsxImportSource`:
+    ```json
+    {
+      "compilerOptions": {
+        "target": "ESNext",
+        "module": "ESNext", // Or "Preserve" if Bun handles JSX files directly
+        "moduleResolution": "bundler", // Or "node"
+        "jsx": "react-jsx",
+        "jsxImportSource": "./src", // Points to where your framework's jsx-runtime is
+        "lib": ["ESNext", "DOM"],
+        "strict": true,
+        "skipLibCheck": true,
+        // ... other options
+      },
+      "include": ["src"] // Ensure your source files are included
+    }
+    ```
+    (The `./src` for `jsxImportSource` assumes your framework's `jsx-runtime.ts` and `jsx.d.ts` are in the `src` directory relative to your project root).
+
+## Core Concepts & API Usage
+
+BunVoyage implements several core concepts found in popular UI libraries.
+
+### JSX
+
+You can use JSX to define your UI structures. Our custom JSX runtime (defined in `src/jsx-runtime.ts` and typed in `src/jsx.d.ts`) translates these JSX expressions into Virtual DOM nodes.
+
+```tsx
+// Example of JSX
+const element = <div id="greeting">Hello, world!</div>;
+
+const MyComponent = ({ name }) => <p>Hello, {name}</p>;
+const componentElement = <MyComponent name="BunVoyage" />;
+```
+
+### Functional Components
+
+Components are JavaScript functions that return renderable output (VNodes). They receive `props` as their first argument.
+
+```tsx
+import { h } from './src'; // Or your framework's main export
+
+const WelcomeMessage = (props) => {
+  return <h1>Hello, {props.name}!</h1>;
+};
+
+// Usage:
+// <WelcomeMessage name="Developer" />
+```
+
+### State (`useState`)
+
+Manage local state within your functional components using the `useState` hook. It returns an array with the current state value and a function to update it.
+
+```tsx
+import { useState, h } from './src';
+
+const Counter = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount(count + 1)}>Increment</button>
+    </div>
+  );
+};
+```
+
+### Props
+
+Props (properties) are passed to components to customize their behavior and output. For HTML elements, props correspond to HTML attributes (like `id`, `className`, `style`) and event handlers (`onClick`, etc.).
+
+```tsx
+const Button = (props) => {
+  // props.onClick, props.children, etc.
+  return <button style={props.style} onClick={props.onClick}>{props.children}</button>;
+}
+
+// Usage:
+// <Button style={{ color: 'blue' }} onClick={() => alert('Clicked!')}>
+//   Click Me
+// </Button>
+```
+Children are passed via the `children` prop.
+
+### Rendering (`render`)
+
+The `render` function is the entry point to mount your application into the DOM.
+
+```tsx
+import { render, h } from './src';
+import App from './App'; // Your root component
+
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  render(<App />, rootElement);
+}
+```
+
+### Fragments (`Fragment`)
+
+Use `Fragment` (or `<></>`) to return multiple children from a component without adding an extra node to the DOM.
+
+```tsx
+import { Fragment, h } from './src'; // Or import { Fragment } from './jsx-runtime'
+
+const UserInfo = () => {
+  return (
+    <Fragment>
+      <p>Name: User</p>
+      <p>Age: 30</p>
+    </Fragment>
+    // Or:
+    // <>
+    //   <p>Name: User</p>
+    //   <p>Age: 30</p>
+    // </>
+  );
+};
+```
+*Note: True shorthand fragment `<></>` support depends on your build setup correctly aliasing it to `Fragment`. Explicitly importing and using `<Fragment>` is always safe.*
+
+## 📝 Example Snippet
+
+A simple counter application demonstrates the basic usage of components, state, and event handling.
+
+```tsx
+// src/example.tsx (Simplified)
+import { render, useState, h, Fragment } from './index';
+
+const Counter = () => {
+  const [count, setCount] = useState(0);
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount(c => c + 1)}>+</button>
+      <button onClick={() => setCount(c => c - 1)}>-</button>
+    </div>
+  );
+};
+
+const App = () => (
+  <Fragment>
+    <h1>Counter App</h1>
+    <Counter />
+  </Fragment>
+);
+
+const root = document.getElementById('root');
+if (root) render(<App />, root);
+```
+For the full, runnable example, please see `src/example.tsx`.
+
+## 🏃 How to Run the Example Application
+
+1.  Ensure you have Bun installed.
+2.  Navigate to the project directory.
+3.  Use Bun's development server to serve the `public/index.html` file:
+    ```bash
+    bun public/index.html
+    ```
+    Or, for hot reloading:
+    ```bash
+    bun --hot public/index.html
+    ```
+4.  Open your browser and go to `http://localhost:3000` (or the port Bun indicates).
+
+Bun will automatically transpile the `src/example.tsx` file and its dependencies.
+
+## 📂 Project Structure Overview
+
+The core framework code resides primarily in the `src` directory:
+```
+.
+├── public/
+│   └── index.html        # Main HTML file to host the app
+├── src/
+│   ├── vdom.ts           # Virtual DOM node definitions, patch function (diffing)
+│   ├── jsx-runtime.ts    # Custom JSX transform functions (h, jsx, jsxs)
+│   ├── jsx.d.ts          # Global JSX type definitions for TypeScript
+│   ├── hooks.ts          # Hook implementations (e.g., useState)
+│   ├── index.ts          # Main framework exports (render, h, useState, etc.)
+│   ├── example.tsx       # Example application code
+│   └── ...               # Other framework modules or components might be added
+├── BUNVOYAGE_README.md   # This framework-specific README
+├── tsconfig.json         # TypeScript configuration
+└── README.md             # Main project README (if applicable)
+```
+
+## Contributing
+
+This project is primarily for educational purposes. Contributions, suggestions, and feedback are welcome as we explore and learn together!
+
+## License
+
+MIT
+```

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,32 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "/app",
+      "dependencies": {
+        "@types/react": "^19.1.6",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
+
+    "@types/node": ["@types/node@22.15.29", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ=="],
+
+    "@types/react": ["@types/react@19.1.6", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q=="],
+
+    "bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
+
+    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+console.log("Hello via Bun!");

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "/app",
+  "module": "index.ts",
+  "type": "module",
+  "private": true,
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  },
+  "dependencies": {
+    "@types/react": "^19.1.6"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bun Custom Framework Example</title>
+    <link rel="icon" href="data:;base64,iVBORw0KGgo="> <!-- Simple favicon to prevent 404 -->
+    <style>
+        body { font-family: sans-serif; display: flex; flex-direction: column; align-items: center; margin-top: 20px; background-color: #f0f0f0; }
+        #root { background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        button { margin: 5px; padding: 10px 15px; font-size: 1em; cursor: pointer; border: none; border-radius: 4px; }
+        button.increment { background-color: #4CAF50; color: white; }
+        button.decrement { background-color: #f44336; color: white; }
+        h1 { color: #333; }
+        p { color: #555; font-size: 1.2em; }
+    </style>
+</head>
+<body>
+    <h1>My Custom Framework App</h1>
+    <div id="root"></div>
+    <!--
+      Bun's dev server, when serving an HTML file, will automatically handle
+      dependencies referenced by <script type="module">.
+      It will resolve and transpile .tsx/.ts files.
+      The path should be relative to the project root if Bun serves from project root,
+      or relative to the public directory if Bun's CWD is public.
+      Let's assume Bun serves from project root and can resolve from `src`.
+    -->
+    <script type="module" src="../src/example.tsx"></script>
+</body>
+</html>

--- a/src/example.tsx
+++ b/src/example.tsx
@@ -1,0 +1,49 @@
+import { render, useState, h, Fragment } from './index'; // Adjusted path assuming example.tsx is in src
+// Note: If using Bun's dev server from project root, and index.html is in public,
+// this path to './index' (which resolves to './index.ts') is correct.
+
+const Counter = () => {
+  const [count, setCount] = useState(0);
+
+  const increment = () => {
+    setCount(prevCount => prevCount + 1);
+  };
+
+  const decrement = () => {
+    setCount(prevCount => prevCount - 1);
+  };
+
+  return (
+    <div>
+      <p>Current count: {count}</p>
+      <button onClick={increment} class="increment">Increment</button>
+      <button onClick={decrement} class="decrement">Decrement</button>
+      {count > 5 && <p>Count is greater than 5!</p>}
+      {count < 0 && (
+        <Fragment>
+          <p>Count is negative!</p>
+          <p>Maybe reset?</p>
+        </Fragment>
+      )}
+    </div>
+  );
+};
+
+const App = () => {
+  return (
+    <Fragment>
+      <h2>Counter Example</h2>
+      <Counter />
+      <hr />
+      <p><em>This is a simple counter app to demonstrate the framework.</em></p>
+    </Fragment>
+  );
+};
+
+const rootElement = document.getElementById('root');
+
+if (rootElement) {
+  render(<App />, rootElement);
+} else {
+  console.error("Root element not found. Make sure you have a div with id='root' in your HTML.");
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,121 @@
+import { VNode, patch, FunctionVNode, ComponentFunction, Props as VNodeProps } from './vdom';
+
+// --- Globals for Hook System ---
+let currentlyRenderingComponent: FunctionComponentInstance<any> | null = null;
+let hookIndex = 0;
+
+// P represents the component's own props (excluding children, key, ref which are in VNodeProps)
+export interface FunctionComponentInstance<P = {}> {
+  id: string;
+  componentFunction: ComponentFunction<P>;
+  props: P & VNodeProps; // Combined props
+  hooks: any[];
+  renderedVNode?: VNode;
+  parentDom?: HTMLElement | Text;
+  oldVNodeRepresentation?: FunctionVNode<P>; // Typed with component's props
+}
+
+let componentInstanceCounter = 0;
+const componentInstanceMap = new Map<string, FunctionComponentInstance<any>>();
+
+export function getComponentInstance<P = {}>(
+  componentFunction: ComponentFunction<P>,
+  props: P & VNodeProps,
+  parentDom: HTMLElement | Text,
+  vNodeRepresentation: FunctionVNode<P>
+): FunctionComponentInstance<P> {
+  const key = props.key || componentFunction.name;
+  // This ID generation needs to be more robust for stable instance identity
+  const instanceId = parentDom ? `${parentDom.nodeName}_${key}_${componentInstanceCounter}` : `${key}_${componentInstanceCounter++}`;
+
+  if (vNodeRepresentation.componentInstance) {
+    const instance = vNodeRepresentation.componentInstance as FunctionComponentInstance<P>;
+    instance.props = props;
+    instance.parentDom = parentDom;
+    instance.oldVNodeRepresentation = vNodeRepresentation;
+    return instance;
+  }
+
+  let instance = componentInstanceMap.get(instanceId) as FunctionComponentInstance<P> | undefined;
+  if (!instance) {
+    instance = {
+      id: instanceId,
+      componentFunction,
+      props,
+      hooks: [],
+      parentDom,
+      oldVNodeRepresentation: vNodeRepresentation,
+    };
+    componentInstanceMap.set(instanceId, instance);
+    vNodeRepresentation.componentInstance = instance;
+  } else {
+    instance.props = props;
+    instance.parentDom = parentDom;
+    instance.oldVNodeRepresentation = vNodeRepresentation;
+    vNodeRepresentation.componentInstance = instance;
+  }
+  return instance;
+}
+
+export function removeComponentInstance(instance: FunctionComponentInstance<any> | undefined) {
+  if (instance) {
+    componentInstanceMap.delete(instance.id);
+    console.log(`Removed component instance ${instance.id}`);
+  }
+}
+
+export function setCurrentRenderingComponent(instance: FunctionComponentInstance<any> | null) {
+  currentlyRenderingComponent = instance;
+  hookIndex = 0;
+}
+
+export function useState<S>(
+  initialState: S | (() => S)
+): [S, (newState: S | ((prevState: S) => S)) => void] {
+  if (!currentlyRenderingComponent) {
+    throw new Error("useState can only be called outside a functional component.");
+  }
+
+  const currentInstance = currentlyRenderingComponent;
+  const currentIndex = hookIndex;
+  hookIndex++;
+
+  if (currentInstance.hooks.length <= currentIndex) {
+    // If initialState is a function, call it to get the actual initial state
+    currentInstance.hooks[currentIndex] = typeof initialState === 'function'
+        ? (initialState as () => S)()
+        : initialState;
+  }
+
+  const setState = (newStateOrFn: S | ((prevState: S) => S)) => {
+    const oldState = currentInstance.hooks[currentIndex] as S;
+    const newState = typeof newStateOrFn === 'function'
+      ? (newStateOrFn as (prevState: S) => S)(oldState)
+      : newStateOrFn;
+
+    if (oldState !== newState) {
+      currentInstance.hooks[currentIndex] = newState;
+
+      if (currentInstance.oldVNodeRepresentation && currentInstance.parentDom) {
+        console.log(`Re-rendering component ${currentInstance.id} due to setState. Old state: ${oldState}, New state: ${newState}`);
+
+        const currentComponentVNode = currentInstance.oldVNodeRepresentation;
+        // Create a new VNode object for the re-render to ensure diffing occurs correctly.
+        // Props are taken from the instance, as they might have been updated by a parent re-render
+        // even if this setState is the trigger.
+        const newComponentVNodeForRender: FunctionVNode<any> = {
+            type: 'function',
+            tag: currentComponentVNode.tag, // The component function
+            props: currentInstance.props,   // Current props from the instance
+            key: currentComponentVNode.key,
+            // componentInstance and renderedVNode will be (re-)assigned by patch
+        };
+        patch(currentComponentVNode, newComponentVNodeForRender, currentInstance.parentDom);
+      } else {
+        console.error("Cannot re-render: missing oldVNodeRepresentation or parentDom on component instance.", currentInstance);
+      }
+    }
+  };
+
+  return [currentInstance.hooks[currentIndex] as S, setState];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,55 @@
+import { VNode, patch } from './vdom';
+import { h, jsx, jsxs, Fragment, FRAGMENT_TYPE } from './jsx-runtime'; // Import FRAGMENT_TYPE for direct use if needed
+import { useState } from './hooks';
+import type { JSX } from './jsx'; // For using JSX namespace types if needed explicitly
+
+// Store the last rendered root VNode for potential re-renders from the root
+let lastRootVNode: VNode | null = null;
+let rootParentDomElement: HTMLElement | null = null;
+
+/**
+ * Renders a VNode into a parent DOM element.
+ * @param vnodeToRender The root VNode (JSX.Element) to render. Can be null to unmount.
+ * @param targetParentDomElement The HTML DOM element to mount the VNode into.
+ */
+export function render(
+  vnodeToRender: JSX.Element | null, // Use JSX.Element for public API clarity
+  targetParentDomElement: HTMLElement
+): void {
+  if (!targetParentDomElement) {
+    throw new Error("Render target parent DOM element not found.");
+  }
+
+  // Clear content only if we are mounting a new root or changing target
+  if (vnodeToRender !== null && (lastRootVNode === null || rootParentDomElement !== targetParentDomElement)) {
+    targetParentDomElement.innerHTML = '';
+  }
+
+  patch(lastRootVNode, vnodeToRender, targetParentDomElement);
+
+  lastRootVNode = vnodeToRender;
+  rootParentDomElement = targetParentDomElement;
+}
+
+// Re-export core API elements
+// The types for h, jsx, jsxs, Fragment, useState are inferred from their definitions.
+export { h, jsx, jsxs, Fragment, useState, FRAGMENT_TYPE };
+
+// Optional: A type for functional components for users of the framework
+export type FunctionalComponent<P = {}> = (props: P & JSX.ElementChildrenAttribute & { key?: string | number }) => JSX.Element | null;
+
+/* Example usage:
+  const App: FunctionalComponent<{ message: string }> = (props) => {
+    return <h1>{props.message} {props.children}</h1>;
+  };
+*/
+
+// Potentially, a function to unmount the root could be added here:
+export function unmountRoot(targetParentDomElement: HTMLElement): void {
+  if (rootParentDomElement === targetParentDomElement && lastRootVNode !== null) {
+    patch(lastRootVNode, null, targetParentDomElement);
+    lastRootVNode = null;
+    // rootParentDomElement = null; // Keep rootParentDomElement to know it was mounted here
+    targetParentDomElement.innerHTML = ''; // Explicitly clear after unpatching
+  }
+}

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,0 +1,140 @@
+import {
+  VNode,
+  ElementVNode,
+  TextVNode,
+  FunctionVNode,
+  Props, // Using the refined Props from vdom.ts
+  ComponentFunction
+} from './vdom';
+import type { JSX } from './jsx'; // Import the global JSX namespace for type checking
+
+// FRAGMENT_TYPE can be a string or symbol. Using a string for 'tag' in VNode.
+export const FRAGMENT_TYPE = 'FRAGMENT';
+
+function createTextVNode(value: string | number, key?: string | number): TextVNode {
+  return { type: 'text', value: String(value), key };
+}
+
+// Overload signatures for h
+// 1. For Intrinsic Elements (HTML tags)
+export function h<K extends keyof JSX.IntrinsicElements>(
+  tag: K,
+  props: JSX.IntrinsicElements[K] | null, // Props specific to the HTML tag
+  ...children: (VNode | string | number | null | undefined)[]
+): ElementVNode;
+
+// 2. For Functional Components
+export function h<P extends {}>(
+  tag: ComponentFunction<P>,
+  props: P & Props | null, // Component's own props + our base VNode props (key, children, ref)
+  ...children: (VNode | string | number | null | undefined)[]
+): FunctionVNode<P>;
+
+// 3. For Fragments
+export function h(
+  tag: typeof FRAGMENT_TYPE,
+  props: Props | null,
+  ...children: (VNode | string | number | null | undefined)[]
+): ElementVNode; // Fragments are treated as ElementVNode with tag 'FRAGMENT'
+
+
+// Implementation of h
+export function h(
+  tag: keyof JSX.IntrinsicElements | ComponentFunction<any> | typeof FRAGMENT_TYPE,
+  props: Props | null,
+  ...childrenInput: any[] // Array of children arguments
+): VNode {
+  let currentProps: Props = props || {};
+
+  // Handle 'class' prop and map it to 'className'
+  if (currentProps.class) {
+    currentProps.className = currentProps.class;
+    delete currentProps.class;
+  }
+
+  const key = currentProps.key || undefined;
+
+  // Children processing:
+  // JSX transform might pass children as third argument or in props.children.
+  // Prefer props.children if it exists (common for jsxs transform), otherwise use childrenInput.
+  const childrenArgs = currentProps.children !== undefined ? currentProps.children : childrenInput;
+  // Children from props should be deleted so they are not passed down if the component also uses rest children
+  if (currentProps.children !== undefined) {
+      delete currentProps.children;
+  }
+
+  const processedChildren: VNode[] = [];
+  const processChild = (child: any, index: number) => {
+    // If child is passed with key (e.g. from array map), use it. Otherwise, generate one.
+    // This basic index key is only for non-explicitly keyed children.
+    const childKey = (child && typeof child === 'object' && child.key !== undefined) ? child.key : `_child_${index}`;
+
+    if (child === null || typeof child === 'boolean' || typeof child === 'undefined') {
+      return; // Ignore these child types
+    }
+    if (typeof child === 'string' || typeof child === 'number') {
+      processedChildren.push(createTextVNode(child, childKey));
+    } else if (Array.isArray(child)) {
+      child.forEach((c, i) => processChild(c, `${index}_${i}`)); // Flatten arrays, extend key
+    } else if (typeof child === 'object' && child !== null && (child.type === 'element' || child.type === 'text' || child.type === 'function')) {
+      // Already a VNode, ensure it has a key or assign one
+      if(child.key === undefined) child.key = childKey;
+      processedChildren.push(child as VNode);
+    } else if (typeof child === 'object' && child !== null && typeof child.tag !== 'undefined') {
+        // This case might be trying to normalize an old VNode-like structure.
+        // It's better if JSX always produces calls to h.
+        const normalizedChild = h(child.tag, child.props, ...(child.children || []));
+        if(normalizedChild.key === undefined) normalizedChild.key = childKey;
+        processedChildren.push(normalizedChild);
+    } else {
+      // Fallback for unknown child types, convert to string
+      console.warn('Unknown child type in h, converting to string:', child);
+      processedChildren.push(createTextVNode(String(child), childKey));
+    }
+  };
+
+  if (Array.isArray(childrenArgs)) {
+    childrenArgs.forEach(processChild);
+  } else if (childrenArgs !== null && childrenArgs !== undefined) {
+    processChild(childrenArgs, 0);
+  }
+
+
+  if (typeof tag === 'function') {
+    // Functional Component
+    currentProps.children = processedChildren; // Pass children as a prop
+    return {
+      type: 'function',
+      tag: tag,
+      props: currentProps as any, // Cast needed because P is generic
+      key: key,
+    } as FunctionVNode<any>;
+  }
+
+  if (tag === FRAGMENT_TYPE) {
+    // Fragment
+    return {
+      type: 'element',
+      tag: FRAGMENT_TYPE,
+      props: currentProps,
+      children: processedChildren,
+      key: key,
+    } as ElementVNode;
+  }
+
+  // Intrinsic Element (HTML tag)
+  return {
+    type: 'element',
+    tag: tag as string, // Cast because K is constrained
+    props: currentProps,
+    children: processedChildren,
+    key: key,
+  } as ElementVNode;
+}
+
+// Aliases for JSX automatic runtime in tsconfig.json
+export const jsx = h;
+export const jsxs = h; // jsxs could be optimized later (e.g. for static children)
+export const jsxDEV = h; // Development version, can add warnings or debug info
+
+export const Fragment = FRAGMENT_TYPE;

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1,0 +1,441 @@
+import { VNode, Props as VNodeProps } from './vdom'; // Assuming VNodeProps will be defined in vdom.ts
+import { FunctionComponentInstance } from './hooks'; // For component props
+
+// Define a base Props type for HTML elements
+// Loosely based on React's HTMLAttributes and CSSProperties
+type DOMEvents = {
+  // Clipboard Events
+  onCopy?: (event: ClipboardEvent) => void;
+  onCut?: (event: ClipboardEvent) => void;
+  onPaste?: (event: ClipboardEvent) => void;
+
+  // Composition Events
+  onCompositionEnd?: (event: CompositionEvent) => void;
+  onCompositionStart?: (event: CompositionEvent) => void;
+  onCompositionUpdate?: (event: CompositionEvent) => void;
+
+  // Focus Events
+  onFocus?: (event: FocusEvent) => void;
+  onBlur?: (event: FocusEvent) => void;
+
+  // Form Events
+  onChange?: (event: Event) => void; // More specific types can be used per element (e.g. InputChangeEvent)
+  onInput?: (event: Event) => void;
+  onReset?: (event: Event) => void;
+  onSubmit?: (event: Event) => void;
+  onInvalid?: (event: Event) => void;
+
+  // Image Events
+  onLoad?: (event: Event) => void;
+  onError?: (event: Event) => void; // also a media event
+
+  // Keyboard Events
+  onKeyDown?: (event: KeyboardEvent) => void;
+  onKeyPress?: (event: KeyboardEvent) => void;
+  onKeyUp?: (event: KeyboardEvent) => void;
+
+  // Media Events
+  onAbort?: (event: Event) => void;
+  onCanPlay?: (event: Event) => void;
+  onCanPlayThrough?: (event: Event) => void;
+  onDurationChange?: (event: Event) => void;
+  onEmptied?: (event: Event) => void;
+  onEncrypted?: (event: Event) => void;
+  onEnded?: (event: Event) => void;
+  onLoadedData?: (event: Event) => void;
+  onLoadedMetadata?: (event: Event) => void;
+  onLoadStart?: (event: Event) => void;
+  onPause?: (event: Event) => void;
+  onPlay?: (event: Event) => void;
+  onPlaying?: (event: Event) => void;
+  onProgress?: (event: Event) => void;
+  onRateChange?: (event: Event) => void;
+  onSeeked?: (event: Event) => void;
+  onSeeking?: (event: Event) => void;
+  onStalled?: (event: Event) => void;
+  onSuspend?: (event: Event) => void;
+  onTimeUpdate?: (event: Event) => void;
+  onVolumeChange?: (event: Event) => void;
+  onWaiting?: (event: Event) => void;
+
+  // MouseEvents
+  onClick?: (event: MouseEvent) => void;
+  onContextMenu?: (event: MouseEvent) => void;
+  onDoubleClick?: (event: MouseEvent) => void;
+  onDrag?: (event: DragEvent) => void;
+  onDragEnd?: (event: DragEvent) => void;
+  onDragEnter?: (event: DragEvent) => void;
+  onDragExit?: (event: DragEvent) => void;
+  onDragLeave?: (event: DragEvent) => void;
+  onDragOver?: (event: DragEvent) => void;
+  onDragStart?: (event: DragEvent) => void;
+  onDrop?: (event: DragEvent) => void;
+  onMouseDown?: (event: MouseEvent) => void;
+  onMouseEnter?: (event: MouseEvent) => void;
+  onMouseLeave?: (event: MouseEvent) => void;
+  onMouseMove?: (event: MouseEvent) => void;
+  onMouseOut?: (event: MouseEvent) => void;
+  onMouseOver?: (event: MouseEvent) => void;
+  onMouseUp?: (event: MouseEvent) => void;
+
+  // Touch Events
+  onTouchCancel?: (event: TouchEvent) => void;
+  onTouchEnd?: (event: TouchEvent) => void;
+  onTouchMove?: (event: TouchEvent) => void;
+  onTouchStart?: (event: TouchEvent) => void;
+
+  // UI Events
+  onScroll?: (event: UIEvent) => void;
+
+  // Wheel Events
+  onWheel?: (event: WheelEvent) => void;
+};
+
+type CSSProperties = Partial<CSSStyleDeclaration>;
+
+export type HTMLAttributes<T extends EventTarget = HTMLElement> = DOMEvents & {
+  // Standard HTML Attributes
+  accept?: string;
+  acceptCharset?: string;
+  accessKey?: string;
+  action?: string;
+  allowFullScreen?: boolean;
+  allowTransparency?: boolean;
+  alt?: string;
+  as?: string;
+  async?: boolean;
+  autoComplete?: string;
+  autoFocus?: boolean;
+  autoPlay?: boolean;
+  capture?: boolean | string;
+  cellPadding?: number | string;
+  cellSpacing?: number | string;
+  charSet?: string;
+  challenge?: string;
+  checked?: boolean;
+  cite?: string;
+  class?: string; // Use 'class' for JSX, will be mapped to 'className' by h() or props handling
+  className?: string; // Allow 'className' as well
+  cols?: number;
+  colSpan?: number;
+  content?: string;
+  contentEditable?: boolean | "inherit";
+  contextMenu?: string;
+  controls?: boolean;
+  coords?: string;
+  crossOrigin?: string;
+  data?: string;
+  dateTime?: string;
+  default?: boolean;
+  defer?: boolean;
+  dir?: 'auto' | 'rtl' | 'ltr';
+  disabled?: boolean;
+  download?: any;
+  draggable?: boolean | "true" | "false";
+  encType?: string;
+  form?: string;
+  formAction?: string;
+  formEncType?: string;
+  formMethod?: string;
+  formNoValidate?: boolean;
+  formTarget?: string;
+  frameBorder?: number | string;
+  headers?: string;
+  height?: number | string;
+  hidden?: boolean;
+  high?: number;
+  href?: string;
+  hrefLang?: string;
+  htmlFor?: string;
+  httpEquiv?: string;
+  id?: string;
+  inputMode?: string;
+  integrity?: string;
+  is?: string;
+  key?: string | number; // Our VNode key
+  keyParams?: string;
+  keyType?: string;
+  kind?: string;
+  label?: string;
+  lang?: string;
+  list?: string;
+  loop?: boolean;
+  low?: number;
+  manifest?: string;
+  marginHeight?: number;
+  marginWidth?: number;
+  max?: number | string;
+  maxLength?: number;
+  media?: string;
+  mediaGroup?: string;
+  method?: string;
+  min?: number | string;
+  minLength?: number;
+  multiple?: boolean;
+  muted?: boolean;
+  name?: string;
+  nonce?: string;
+  noValidate?: boolean;
+  open?: boolean;
+  optimum?: number;
+  pattern?: string;
+  placeholder?: string;
+  playsInline?: boolean;
+  poster?: string;
+  preload?: string;
+  radioGroup?: string;
+  readOnly?: boolean;
+  rel?: string;
+  required?: boolean;
+  reversed?: boolean;
+  role?: string;
+  rows?: number;
+  rowSpan?: number;
+  sandbox?: string;
+  scope?: string;
+  scoped?: boolean;
+  scrolling?: string;
+  seamless?: boolean;
+  selected?: boolean;
+  shape?: string;
+  size?: number;
+  sizes?: string;
+  slot?: string;
+  span?: number;
+  spellCheck?: boolean | "true" | "false";
+  src?: string;
+  srcDoc?: string;
+  srcLang?: string;
+  srcSet?: string;
+  start?: number;
+  step?: number | string;
+  style?: CSSProperties | string; // Allow string for direct CSS text
+  summary?: string;
+  tabIndex?: number;
+  target?: string;
+  title?: string;
+  type?: string;
+  useMap?: string;
+  value?: string | string[] | number;
+  width?: number | string;
+  wmode?: string;
+  wrap?: string;
+
+  // RDFa Attributes
+  about?: string;
+  datatype?: string;
+  inlist?: any;
+  prefix?: string;
+  property?: string;
+  resource?: string;
+  typeof?: string;
+  vocab?: string;
+
+  // Non-standard Attributes
+  autoCapitalize?: string;
+  autoCorrect?: string;
+  autoSave?: string;
+  color?: string;
+  itemProp?: string;
+  itemScope?: boolean;
+  itemType?: string;
+  itemID?: string;
+  itemRef?: string;
+  results?: number;
+  security?: string;
+  unselectable?: 'on' | 'off';
+};
+
+// Type for children
+type Children = VNode | string | number | null | undefined | Array<VNode | string | number | null | undefined>;
+
+// Props for our components should include children, and optionally key
+export interface ComponentProps {
+  children?: Children;
+  key?: string | number;
+  ref?: (element: HTMLElement | Text | FunctionComponentInstance | undefined) => void; // Basic ref support
+}
+
+// This is the core of JSX typing
+declare global {
+  namespace JSX {
+    // JSX expressions resolve to this type
+    type Element = VNode;
+
+    // Specifies the children prop name
+    interface ElementChildrenAttribute {
+      children: {}; // children prop is named 'children'
+    }
+
+    // Props for components that are functions
+    // P are the component's own props. Our ComponentProps adds 'children' and 'key'.
+    // type Component<P = {}> = (props: P & ComponentProps) => Element | null;
+
+
+    // Intrinsic elements (HTML tags)
+    // Tries to map HTML tag names to their specific element type and props
+    interface IntrinsicElements {
+      // HTML
+      a: HTMLAttributes<HTMLAnchorElement> & { children?: Children };
+      abbr: HTMLAttributes<HTMLElement> & { children?: Children };
+      address: HTMLAttributes<HTMLElement> & { children?: Children };
+      area: HTMLAttributes<HTMLAreaElement> & { children?: Children };
+      article: HTMLAttributes<HTMLElement> & { children?: Children };
+      aside: HTMLAttributes<HTMLElement> & { children?: Children };
+      audio: HTMLAttributes<HTMLAudioElement> & { children?: Children };
+      b: HTMLAttributes<HTMLElement> & { children?: Children };
+      base: HTMLAttributes<HTMLBaseElement> & { children?: Children };
+      bdi: HTMLAttributes<HTMLElement> & { children?: Children };
+      bdo: HTMLAttributes<HTMLElement> & { children?: Children };
+      big: HTMLAttributes<HTMLElement> & { children?: Children };
+      blockquote: HTMLAttributes<HTMLQuoteElement> & { children?: Children }; // Corrected
+      body: HTMLAttributes<HTMLBodyElement> & { children?: Children };
+      br: HTMLAttributes<HTMLBRElement> & { children?: Children };
+      button: HTMLAttributes<HTMLButtonElement> & { children?: Children };
+      canvas: HTMLAttributes<HTMLCanvasElement> & { children?: Children };
+      caption: HTMLAttributes<HTMLTableCaptionElement> & { children?: Children }; // Corrected
+      cite: HTMLAttributes<HTMLElement> & { children?: Children };
+      code: HTMLAttributes<HTMLElement> & { children?: Children };
+      col: HTMLAttributes<HTMLTableColElement> & { children?: Children }; // Corrected
+      colgroup: HTMLAttributes<HTMLTableColElement> & { children?: Children }; // Corrected
+      data: HTMLAttributes<HTMLDataElement> & { children?: Children }; // Corrected
+      datalist: HTMLAttributes<HTMLDataListElement> & { children?: Children };
+      dd: HTMLAttributes<HTMLElement> & { children?: Children };
+      del: HTMLAttributes<HTMLModElement> & { children?: Children }; // Corrected (for <del>)
+      details: HTMLAttributes<HTMLDetailsElement> & { children?: Children }; // Corrected
+      dfn: HTMLAttributes<HTMLElement> & { children?: Children };
+      dialog: HTMLAttributes<HTMLDialogElement> & { children?: Children };
+      div: HTMLAttributes<HTMLDivElement> & { children?: Children };
+      dl: HTMLAttributes<HTMLDListElement> & { children?: Children };
+      dt: HTMLAttributes<HTMLElement> & { children?: Children };
+      em: HTMLAttributes<HTMLElement> & { children?: Children };
+      embed: HTMLAttributes<HTMLEmbedElement> & { children?: Children };
+      fieldset: HTMLAttributes<HTMLFieldSetElement> & { children?: Children };
+      figcaption: HTMLAttributes<HTMLElement> & { children?: Children };
+      figure: HTMLAttributes<HTMLElement> & { children?: Children };
+      footer: HTMLAttributes<HTMLElement> & { children?: Children };
+      form: HTMLAttributes<HTMLFormElement> & { children?: Children };
+      h1: HTMLAttributes<HTMLHeadingElement> & { children?: Children };
+      h2: HTMLAttributes<HTMLHeadingElement> & { children?: Children };
+      h3: HTMLAttributes<HTMLHeadingElement> & { children?: Children };
+      h4: HTMLAttributes<HTMLHeadingElement> & { children?: Children };
+      h5: HTMLAttributes<HTMLHeadingElement> & { children?: Children };
+      h6: HTMLAttributes<HTMLHeadingElement> & { children?: Children };
+      head: HTMLAttributes<HTMLHeadElement> & { children?: Children };
+      header: HTMLAttributes<HTMLElement> & { children?: Children };
+      hgroup: HTMLAttributes<HTMLElement> & { children?: Children };
+      hr: HTMLAttributes<HTMLHRElement> & { children?: Children };
+      html: HTMLAttributes<HTMLHtmlElement> & { children?: Children };
+      i: HTMLAttributes<HTMLElement> & { children?: Children };
+      iframe: HTMLAttributes<HTMLIFrameElement> & { children?: Children };
+      img: HTMLAttributes<HTMLImageElement> & { children?: Children };
+      input: HTMLAttributes<HTMLInputElement> & { children?: Children; onChange?: (event: InputEvent) => void; };
+      ins: HTMLAttributes<HTMLModElement> & { children?: Children }; // Corrected (for <ins>)
+      kbd: HTMLAttributes<HTMLElement> & { children?: Children };
+      keygen: HTMLAttributes<HTMLElement> & { children?: Children }; // Deprecated but for completeness
+      label: HTMLAttributes<HTMLLabelElement> & { children?: Children };
+      legend: HTMLAttributes<HTMLLegendElement> & { children?: Children };
+      li: HTMLAttributes<HTMLLIElement> & { children?: Children };
+      link: HTMLAttributes<HTMLLinkElement> & { children?: Children };
+      main: HTMLAttributes<HTMLElement> & { children?: Children };
+      map: HTMLAttributes<HTMLMapElement> & { children?: Children };
+      mark: HTMLAttributes<HTMLElement> & { children?: Children };
+      menu: HTMLAttributes<HTMLMenuElement> & { children?: Children };
+      menuitem: HTMLAttributes<HTMLElement> & { children?: Children }; // For context menus
+      meta: HTMLAttributes<HTMLMetaElement> & { children?: Children };
+      meter: HTMLAttributes<HTMLMeterElement> & { children?: Children }; // Corrected
+      nav: HTMLAttributes<HTMLElement> & { children?: Children };
+      noindex: HTMLAttributes<HTMLElement> & { children?: Children }; // Non-standard
+      noscript: HTMLAttributes<HTMLElement> & { children?: Children };
+      object: HTMLAttributes<HTMLObjectElement> & { children?: Children };
+      ol: HTMLAttributes<HTMLOListElement> & { children?: Children };
+      optgroup: HTMLAttributes<HTMLOptGroupElement> & { children?: Children };
+      option: HTMLAttributes<HTMLOptionElement> & { children?: Children };
+      output: HTMLAttributes<HTMLOutputElement> & { children?: Children }; // Corrected
+      p: HTMLAttributes<HTMLParagraphElement> & { children?: Children };
+      param: HTMLAttributes<HTMLParamElement> & { children?: Children };
+      picture: HTMLAttributes<HTMLPictureElement> & { children?: Children }; // Corrected
+      pre: HTMLAttributes<HTMLPreElement> & { children?: Children };
+      progress: HTMLAttributes<HTMLProgressElement> & { children?: Children };
+      q: HTMLAttributes<HTMLQuoteElement> & { children?: Children };
+      rp: HTMLAttributes<HTMLElement> & { children?: Children };
+      rt: HTMLAttributes<HTMLElement> & { children?: Children };
+      ruby: HTMLAttributes<HTMLElement> & { children?: Children };
+      s: HTMLAttributes<HTMLElement> & { children?: Children };
+      samp: HTMLAttributes<HTMLElement> & { children?: Children };
+      script: HTMLAttributes<HTMLScriptElement> & { children?: Children };
+      section: HTMLAttributes<HTMLElement> & { children?: Children };
+      select: HTMLAttributes<HTMLSelectElement> & { children?: Children; onChange?: (event: Event & { target: HTMLSelectElement }) => void; };
+      small: HTMLAttributes<HTMLElement> & { children?: Children };
+      source: HTMLAttributes<HTMLSourceElement> & { children?: Children };
+      span: HTMLAttributes<HTMLSpanElement> & { children?: Children };
+      strong: HTMLAttributes<HTMLElement> & { children?: Children };
+      style: HTMLAttributes<HTMLStyleElement> & { children?: Children }; // Content via children or dangerouslySetInnerHTML
+      sub: HTMLAttributes<HTMLElement> & { children?: Children };
+      summary: HTMLAttributes<HTMLElement> & { children?: Children }; // Inside <details>
+      sup: HTMLAttributes<HTMLElement> & { children?: Children };
+      table: HTMLAttributes<HTMLTableElement> & { children?: Children };
+      template: HTMLAttributes<HTMLTemplateElement> & { children?: Children }; // Corrected
+      tbody: HTMLAttributes<HTMLTableSectionElement> & { children?: Children }; // Corrected
+      td: HTMLAttributes<HTMLTableCellElement> & { children?: Children }; // Corrected
+      textarea: HTMLAttributes<HTMLTextAreaElement> & { children?: Children; onChange?: (event: Event & { target: HTMLTextAreaElement }) => void; };
+      tfoot: HTMLAttributes<HTMLTableSectionElement> & { children?: Children }; // Corrected
+      th: HTMLAttributes<HTMLTableCellElement> & { children?: Children }; // Corrected
+      thead: HTMLAttributes<HTMLTableSectionElement> & { children?: Children }; // Corrected
+      time: HTMLAttributes<HTMLTimeElement> & { children?: Children }; // Corrected
+      title: HTMLAttributes<HTMLTitleElement> & { children?: Children };
+      tr: HTMLAttributes<HTMLTableRowElement> & { children?: Children };
+      track: HTMLAttributes<HTMLTrackElement> & { children?: Children };
+      u: HTMLAttributes<HTMLElement> & { children?: Children };
+      ul: HTMLAttributes<HTMLUListElement> & { children?: Children };
+      var: HTMLAttributes<HTMLElement> & { children?: Children };
+      video: HTMLAttributes<HTMLVideoElement> & { children?: Children };
+      wbr: HTMLAttributes<HTMLElement> & { children?: Children };
+
+      // SVG Elements (basic outline)
+      svg: SVGAttributes & { children?: Children };
+      // ... other SVG elements like path, circle, rect, etc.
+    }
+
+    // Basic SVG attributes (can be expanded)
+    interface SVGAttributes extends HTMLAttributes<SVGElement> {
+        cx?: number | string;
+        cy?: number | string;
+        d?: string;
+        fill?: string;
+        fx?: number | string;
+        fy?: number | string;
+        gradientTransform?: string;
+        gradientUnits?: string;
+        height?: number | string;
+        points?: string;
+        preserveAspectRatio?: string;
+        r?: number | string;
+        rx?: number | string;
+        ry?: number | string;
+        spreadMethod?: string;
+        stopColor?: string;
+        stopOpacity?: number | string;
+        stroke?: string;
+        strokeDasharray?: string | number;
+        strokeDashoffset?: string | number;
+        strokeLinecap?: "butt" | "round" | "square" | "inherit";
+        strokeLinejoin?: "miter" | "round" | "bevel" | "inherit";
+        strokeMiterlimit?: string | number;
+        strokeOpacity?: number | string;
+        strokeWidth?: number | string;
+        transform?: string;
+        viewBox?: string;
+        width?: number | string;
+        x1?: number | string;
+        x2?: number | string;
+        x?: number | string;
+        y1?: number | string;
+        y2?: number | string;
+        y?: number | string;
+    }
+  }
+}
+
+// Make VNodeProps available for import in jsx.d.ts if needed, though global JSX should use its own types
+export {};

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -1,0 +1,277 @@
+import {
+  getComponentInstance,
+  setCurrentRenderingComponent,
+  FunctionComponentInstance,
+  removeComponentInstance
+} from './hooks';
+import type { HTMLAttributes, ComponentProps as BaseComponentProps, Children } from './jsx'; // Import from jsx.d.ts
+
+// Define a more specific Props type for internal VNode usage
+// It combines HTMLAttributes (for DOM elements) and BaseComponentProps (for key, children, ref)
+// and allows any other string-keyed properties for custom data-* attributes or other needs.
+export type Props = HTMLAttributes & BaseComponentProps & {
+  [key: string]: any; // Allow other props
+  children?: Children; // Ensure children from jsx.d.ts is used
+};
+
+export type TextVNode = {
+  type: 'text';
+  value: string;
+  dom?: Text;
+  key?: string | number; // Text nodes can also have keys in some frameworks
+};
+
+export type ElementVNode = {
+  type: 'element';
+  tag: string; // For HTML elements or 'FRAGMENT'
+  props: Props; // Use the refined Props type
+  children: VNode[];
+  key?: string | number;
+  dom?: HTMLElement | Text; // Text for FRAGMENT's placeholder
+};
+
+export type ComponentFunction<P = {}> = (props: P & BaseComponentProps) => VNode;
+
+export type FunctionVNode<P = {}> = {
+  type: 'function';
+  tag: ComponentFunction<P>; // The component function itself
+  props: P & BaseComponentProps; // Props for the component
+  key?: string | number;
+  componentInstance?: FunctionComponentInstance;
+  renderedVNode?: VNode; // The VNode tree this component function returned
+  dom?: HTMLElement | Text; // The root DOM node of the renderedVNode
+};
+
+export type VNode = ElementVNode | TextVNode | FunctionVNode<any>;
+
+
+function updateDomProperties(
+  dom: HTMLElement,
+  oldProps: Props,
+  newProps: Props
+) {
+  // Remove old properties that are not in newProps
+  for (const key in oldProps) {
+    if (key === 'children' || key === 'key' || (key === 'ref' && typeof oldProps[key] === 'function')) continue;
+    if (!(key in newProps)) {
+      if (key.startsWith('on') && typeof oldProps[key] === 'function') {
+        dom.removeEventListener(key.substring(2).toLowerCase(), oldProps[key] as EventListener);
+      } else if (key === 'className' || key === 'class') { // handle 'class' as well
+        dom.className = '';
+      } else if (key === 'style' && typeof oldProps[key] === 'object') {
+        for (const styleKey in (oldProps[key] as CSSStyleDeclaration)) {
+          (dom.style as any)[styleKey] = '';
+        }
+      } else {
+        dom.removeAttribute(key);
+      }
+    }
+  }
+
+  // Add/update new properties
+  for (const key in newProps) {
+    if (key === 'children' || key === 'key' || (key === 'ref' && typeof newProps[key] === 'function')) continue;
+
+    const oldValue = oldProps[key];
+    const newValue = newProps[key];
+
+    if (oldValue === newValue) continue;
+
+    if (key.startsWith('on') && typeof newValue === 'function') {
+      const eventName = key.substring(2).toLowerCase();
+      if (typeof oldValue === 'function') {
+        dom.removeEventListener(eventName, oldValue as EventListener);
+      }
+      dom.addEventListener(eventName, newValue as EventListener);
+    } else if (key === 'className' || key === 'class') {
+      dom.className = newValue as string;
+    } else if (key === 'style' && typeof newValue === 'object') {
+      if (typeof oldValue === 'object') {
+        for (const styleKey in (oldValue as CSSStyleDeclaration)) {
+          if (!(newValue as any)[styleKey]) {
+            (dom.style as any)[styleKey] = '';
+          }
+        }
+      }
+      for (const styleKey in (newValue as CSSStyleDeclaration)) {
+        (dom.style as any)[styleKey] = (newValue as any)[styleKey];
+      }
+    } else if (key === 'value' && dom.nodeName === 'INPUT') { // Special handling for input value
+        (dom as HTMLInputElement).value = newValue as string;
+    } else if (key === 'checked' && dom.nodeName === 'INPUT') { // Special handling for input checked
+        (dom as HTMLInputElement).checked = newValue as boolean;
+    } else {
+      if (newValue === null || newValue === undefined || newValue === false) {
+        dom.removeAttribute(key);
+      } else {
+        dom.setAttribute(key, String(newValue));
+      }
+    }
+  }
+  // Handle ref: Call the new ref function if it exists, or old one with null if it changed/removed
+  if (typeof oldProps.ref === 'function' && oldProps.ref !== newProps.ref) {
+    oldProps.ref(null);
+  }
+  if (typeof newProps.ref === 'function') {
+    newProps.ref(dom);
+  }
+}
+
+
+export function patch(
+  oldVNode: VNode | null,
+  newVNode: VNode | null,
+  parentDomElement: HTMLElement | Text | null
+): HTMLElement | Text | undefined {
+
+  // 1. Handle removal
+  if (newVNode === null) {
+    if (oldVNode) {
+      if (typeof oldVNode.props?.ref === 'function') oldVNode.props.ref(null); // Call ref with null on removal
+
+      if (oldVNode.type === 'function' && oldVNode.componentInstance) {
+        patch(oldVNode.renderedVNode || null, null, null);
+        removeComponentInstance(oldVNode.componentInstance);
+      }
+      if (oldVNode.dom && oldVNode.dom.parentNode) {
+        oldVNode.dom.parentNode.removeChild(oldVNode.dom);
+      }
+    }
+    return undefined;
+  }
+
+  // At this point, newVNode is not null.
+
+  // 2. Handle initial render (oldVNode is null)
+  if (oldVNode === null) {
+    if (newVNode.type === 'text') {
+      newVNode.dom = document.createTextNode(newVNode.value);
+    } else if (newVNode.type === 'element') {
+      if (newVNode.tag === 'FRAGMENT') {
+        newVNode.dom = document.createTextNode(''); // Placeholder for fragment
+      } else {
+        newVNode.dom = document.createElement(newVNode.tag);
+        updateDomProperties(newVNode.dom as HTMLElement, {} as Props, newVNode.props);
+      }
+      if (newVNode.tag !== 'FRAGMENT') {
+        newVNode.children.forEach(child => patch(null, child, newVNode.dom as HTMLElement));
+      } else {
+         newVNode.children.forEach(child => patch(null, child, parentDomElement)); // Fragment children to actual parent
+      }
+    } else if (newVNode.type === 'function') {
+      // Type assertion for newVNode as FunctionVNode is needed if not narrowed enough
+      const funcVNode = newVNode as FunctionVNode<any>;
+      const instance = getComponentInstance(funcVNode.tag, funcVNode.props, parentDomElement!, funcVNode);
+      funcVNode.componentInstance = instance;
+      instance.props = funcVNode.props;
+      instance.parentDom = parentDomElement!;
+      instance.oldVNodeRepresentation = funcVNode;
+
+      setCurrentRenderingComponent(instance);
+      const rendered = funcVNode.tag(funcVNode.props);
+      setCurrentRenderingComponent(null);
+
+      funcVNode.renderedVNode = rendered;
+      instance.renderedVNode = rendered;
+
+      const dom = patch(null, rendered, parentDomElement);
+      funcVNode.dom = dom;
+      if (typeof funcVNode.props.ref === 'function') funcVNode.props.ref(instance); // Call ref with component instance
+    }
+
+    if (newVNode.dom && newVNode.tag !== 'FRAGMENT' && parentDomElement) {
+       parentDomElement.appendChild(newVNode.dom);
+    }
+    // If it's a fragment and has a placeholder, and needs explicit append (usually not)
+    // else if (newVNode.tag === 'FRAGMENT' && parentDomElement && newVNode.dom && !parentDomElement.contains(newVNode.dom)) {
+    //    parentDomElement.appendChild(newVNode.dom);
+    // }
+    if (newVNode.type !== 'function' && typeof newVNode.props?.ref === 'function') newVNode.props.ref(newVNode.dom);
+
+
+    return newVNode.dom;
+  }
+
+  // At this point, both oldVNode and newVNode exist and are not null.
+  let domElement = oldVNode.dom;
+
+  // 3. Handle different types or tags (replacement)
+  if (oldVNode.type !== newVNode.type ||
+      (oldVNode.type === 'element' && newVNode.type === 'element' && oldVNode.tag !== newVNode.tag) ||
+      (oldVNode.type === 'function' && newVNode.type === 'function' && oldVNode.tag !== newVNode.tag)) {
+    patch(oldVNode, null, null); // Remove old node
+    const newDom = patch(null, newVNode, parentDomElement); // Mount new node
+    return newDom;
+  }
+
+  // 4. Handle same type updates
+  newVNode.dom = domElement; // Carry over DOM reference
+
+  if (newVNode.type === 'text' && oldVNode.type === 'text') {
+    if (oldVNode.value !== newVNode.value) {
+      domElement!.nodeValue = newVNode.value;
+    }
+  } else if (newVNode.type === 'element' && oldVNode.type === 'element' && newVNode.tag !== 'FRAGMENT') {
+    const currentDom = domElement as HTMLElement;
+    updateDomProperties(currentDom, oldVNode.props, newVNode.props);
+
+    const oldChildren = oldVNode.children;
+    const newChildren = newVNode.children; // These are VNodes from h()
+    const commonLength = Math.min(oldChildren.length, newChildren.length);
+
+    for (let i = 0; i < commonLength; i++) {
+      patch(oldChildren[i], newChildren[i], currentDom);
+    }
+    if (newChildren.length > oldChildren.length) {
+      for (let i = commonLength; i < newChildren.length; i++) {
+        patch(null, newChildren[i], currentDom);
+      }
+    } else if (oldChildren.length > newChildren.length) {
+      for (let i = commonLength; i < oldChildren.length; i++) {
+        patch(oldChildren[i], null, currentDom);
+      }
+    }
+  } else if (newVNode.type === 'element' && oldVNode.type === 'element' && newVNode.tag === 'FRAGMENT') {
+    const oldChildren = oldVNode.children;
+    const newChildren = newVNode.children;
+    const commonLength = Math.min(oldChildren.length, newChildren.length);
+    for (let i = 0; i < commonLength; i++) {
+        patch(oldChildren[i], newChildren[i], parentDomElement); // Children of fragment go to actual parent
+    }
+    if (newChildren.length > oldChildren.length) {
+        for (let i = commonLength; i < newChildren.length; i++) {
+            patch(null, newChildren[i], parentDomElement);
+        }
+    } else if (oldChildren.length > newChildren.length) {
+        for (let i = commonLength; i < oldChildren.length; i++) {
+            patch(oldChildren[i], null, parentDomElement);
+        }
+    }
+  } else if (newVNode.type === 'function' && oldVNode.type === 'function' && oldVNode.tag === newVNode.tag) {
+    const funcVNode = newVNode as FunctionVNode<any>;
+    const oldFuncVNode = oldVNode as FunctionVNode<any>;
+
+    funcVNode.componentInstance = oldFuncVNode.componentInstance;
+    funcVNode.componentInstance!.props = funcVNode.props;
+    funcVNode.componentInstance!.parentDom = parentDomElement!;
+    funcVNode.componentInstance!.oldVNodeRepresentation = funcVNode;
+
+    // Handle ref update for component
+    if (oldFuncVNode.props.ref !== funcVNode.props.ref) {
+        if (typeof oldFuncVNode.props.ref === 'function') oldFuncVNode.props.ref(null);
+        if (typeof funcVNode.props.ref === 'function') funcVNode.props.ref(funcVNode.componentInstance);
+    }
+
+
+    setCurrentRenderingComponent(funcVNode.componentInstance!);
+    const newRenderedTree = funcVNode.tag(funcVNode.props);
+    setCurrentRenderingComponent(null);
+
+    const newDom = patch(oldFuncVNode.renderedVNode || null, newRenderedTree, parentDomElement);
+    funcVNode.renderedVNode = newRenderedTree;
+    funcVNode.dom = newDom;
+    funcVNode.componentInstance!.renderedVNode = newRenderedTree;
+  }
+
+  return newVNode.dom;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "jsxImportSource": "./src",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}


### PR DESCRIPTION
This commit introduces a new lightweight frontend framework designed to run with Bun, leveraging JSX for templating and emphasizing strong type safety with TypeScript.

Key features include:

- **JSX Transformation:** Custom JSX runtime (`h`, `jsx`, `jsxs`) that converts JSX into virtual DOM nodes. Configured via `jsxImportSource`.
- **Virtual DOM:** Implementation of VNodes, a diffing algorithm, and a patching mechanism to efficiently update the actual DOM. Supports elements, text nodes, and functional components.
- **Component Model:**
    - Functional components as the primary way to build UI.
    - `useState` hook for managing component-local state and triggering re-renders.
    - Props handling, including `children`.
- **Rendering Engine:** A top-level `render` function to mount the application and manage root-level updates.
- **Type Safety:** Comprehensive TypeScript definitions, including a global `JSX` namespace for intrinsic element type checking and autocompletion.
- **Example Application:** A "Counter" application demonstrates the framework's usage.
- **Documentation:** A `BUNVOYAGE_README.md` file details the framework's API, setup, and core concepts.

This framework serves as a foundational exploration into building UI libraries with modern JavaScript tools like Bun and TypeScript.